### PR TITLE
Adjust linter settings to fit Swing and project conventions

### DIFF
--- a/.github/linters/java_linter_config.xml
+++ b/.github/linters/java_linter_config.xml
@@ -81,7 +81,7 @@
     <module name="InvalidJavadocPosition"/>
     <module name="JavadocMethod"/>
     <module name="JavadocType"/>
-    <module name="JavadocVariable"/>
+    <module name="JavadocVariable">
         <property name="scope" value="public"/>
     </module>
     <module name="JavadocStyle"/>


### PR DESCRIPTION
Don't require comments for private attributes. Remove checking for parameter finality.