### PR TITLE
Removed character encoding parameter for reading TIDE output

### DIFF
--- a/src/main/java/com/api/ApiHandler.java
+++ b/src/main/java/com/api/ApiHandler.java
@@ -63,8 +63,7 @@ public class ApiHandler {
             ProcessBuilder pb = new ProcessBuilder(COURSES_COMMAND.split("\\s+"));
             pb.redirectErrorStream(true);
             Process process = pb.start();
-            // need to use ISO_8859_1 to properly display TIM response in case of ääöö
-            BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.ISO_8859_1));
+            BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
             String line;
             while ((line = reader.readLine()) != null) {
                 jsonString.append(line);


### PR DESCRIPTION
Apparently no need for character encoding workaround