### PR TITLE
Fixed linux incompatibility with download path

### DIFF
--- a/src/main/java/com/api/ApiHandler.java
+++ b/src/main/java/com/api/ApiHandler.java
@@ -91,7 +91,8 @@ public class ApiHandler {
     public void loadExercise(String timPath) throws IOException, InterruptedException {
         String destination = Settings.getPath();
         // Destination path is surrounded by quotes only if it contains spaces.
-        String command = this.taskCreateCommand + " " + timPath + " -d " + (destination.contains(" ") ? "\"" + destination + "\"" : destination);
+        String command = this.taskCreateCommand + " " + timPath + " -d "
+                + (destination.contains(" ") ? "\"" + destination + "\"" : destination);
         ProcessBuilder pb = new ProcessBuilder(command.split("\\s+"));
         // Without the following, is it assumed that destination folder is in sub path of plugin's working directory or something like that.
         // The process will exit with exit code 1 when it discovers that files are saved elsewhere


### PR DESCRIPTION
The api call to download a demo was wrapping the path in quotes just to be safe. However, this made it work incorrectly on our Linux workstations. For example, if the download path was set to
/home/lajyalsa/kurssit
The plugin would download the demo into /home/lajyalsa/kurssit/"/home/lajyalsa/kurssit"/
This was fixed by a conditional statement that checks if the path contains spaces, which is why the quotes were there to begin with.