### PR TITLE
Fix regex

### DIFF
--- a/src/main/java/com/api/JsonHandler.java
+++ b/src/main/java/com/api/JsonHandler.java
@@ -144,7 +144,7 @@ public class JsonHandler {
             if (courseName != null) {
                                        // replace colon preceded by non-whitespace and followed by whitespace
                                        // rationale: "course 1: topic" -> "course 1 - topic"
-                courseName = courseName.replaceAll("\\S[:]\\s+", " - ")
+                courseName = courseName.replaceAll("[:](?<=\\S)\\s+", " - ")
                                        // replace \, /, ", ?, *, |, <, > and remaining colons
                                        .replaceAll("[\\\\/\"?*|<>:]", "-")
                                        .trim();


### PR DESCRIPTION
Use lookbehind to match only colon and the following whitespace, unlike the previous version which matched also the preceding non-whitespace character.