### PR TITLE
Remove unneeded OutputWindow opens

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ plugins {
 }
 
 group = "org.jyu"
-version = "1.0.2"
+version = "1.0.3"
 
 intellijPlatform {
     pluginConfiguration {

--- a/src/main/java/com/views/CourseTaskPane.java
+++ b/src/main/java/com/views/CourseTaskPane.java
@@ -151,7 +151,6 @@ public class CourseTaskPane {
                 com.views.InfoView.displayWarning("No files open in editor!");
                 return;
             }
-            OutputWindow.showWindow(project);
 
             VirtualFile file = FileEditorManager
                     .getInstance(project)

--- a/src/main/java/com/views/CustomScreen.java
+++ b/src/main/java/com/views/CustomScreen.java
@@ -308,7 +308,6 @@ public class CustomScreen {
                 System.out.println(courseTask.getPath());
                 ApiHandler api = new ApiHandler();
                 try {
-                    OutputWindow.showWindow(project);
                     api.loadExercise(courseName, courseTask.getPath(), "--all");
                 } catch (IOException ex) {
                     com.api.LogHandler.logError("268 CustomScreen.createExercise(CourseTask courseTask, String courseName)", ex);


### PR DESCRIPTION
Reset and download don't need to open an output window since the output now gets printed to an infoview bubble.