### PR TITLE
Misc outputwindow tweaks

### DIFF
--- a/src/main/java/com/state/ActiveState.java
+++ b/src/main/java/com/state/ActiveState.java
@@ -17,7 +17,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.openapi.wm.ToolWindowManager;
 import com.util.Util;
 import com.views.InfoView;
 import com.views.OutputWindow;


### PR DESCRIPTION
No need to hide toolwindows as setting them unavailable takes care of it. Clear output window on logout so that previous output will not show when the user logs back in.